### PR TITLE
Use permanent redirect by default + small cleanups & new tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # forcedomain
 
-forcedomain is a middleware for Connect and Epxpress that redirects any request to a default domain.
+forcedomain is a middleware for Connect and Express that redirects any request to a default domain. It is commonly used to redirect to either the non-www or the www version of a domain.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ app.use(forceDomain({
 }));
 ```
 
-By default, forcedomain creates a `temporary` request. If you want to use a `permanent` redirect instead, specify it as redirection type:
+By default, forcedomain creates a `permanent` request - using a permanent redirect is generally considered better for Search Engine Optimisation as it tells search Googlebot / Bingbot etc. that there is a single, long term canonical URL for the resource. If you want to use a `temporary` redirect instead, specify it as redirection type:
 
 ```javascript
 app.use(forceDomain({
   hostname: 'www.example.com',
-  type: 'permanent'
+  type: 'temporary'
 }));
 ```
 

--- a/lib/forceDomain.js
+++ b/lib/forceDomain.js
@@ -11,7 +11,7 @@ var forceDomain = function (options) {
       return next();
     }
 
-    statusCode = (newRoute.type === 'permanent') ? 301 : 307;
+    statusCode = (newRoute.type === 'temporary') ? 307 : 301;
 
     res.writeHead(statusCode, {
       Location: newRoute.url

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -24,7 +24,7 @@ var redirect = function (protocol, hostHeader, url, options) {
     (hostname === 'localhost') ||
     (hostname === options.hostname && port === options.port && protocol === options.protocol)
   ) {
-    return;
+    return null;
   }
 
   route = options.protocol + '://' + hostname + (port ? ':' + port : '') + url;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forcedomain",
   "version": "0.3.0",
-  "description": "forcedomain is a middleware for Connect and Epxpress that redirects any requests to a default domain.",
+  "description": "forcedomain is a middleware for Connect and Express that redirects any requests to a default domain.",
   "contributors": [
     {
       "name": "Golo Roden",
@@ -10,6 +10,10 @@
     {
       "name": "David Bohner",
       "email": "david.bohner@gmail.com"
+    },
+    {
+      "name": "Mike MacCana",
+      "email": "mike.maccana@gmail.com"
     }
   ],
   "main": "lib/forceDomain.js",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "type": "git",
     "url": "git://github.com/goloroden/forcedomain.git"
   },
+  "scripts": {
+    "test": "grunt test"
+  },
   "keywords": [
     "connect",
     "express",

--- a/test/redirectTests.js
+++ b/test/redirectTests.js
@@ -31,6 +31,23 @@ suite('redirect', function () {
       })).is.null();
       done();
     });
+
+    test('for the forced domain with the correct port.', function (done) {
+      assert.that(redirect('http', 'www.thenativeweb.io:4000', '/foo/bar', {
+        hostname: 'www.thenativeweb.io',
+        port: 4000
+      })).is.null();
+      done();
+    });
+
+    test('when non-www is preferred', function (done) {
+      assert.that(redirect('https', 'thenativeweb.io', '/foo/bar', {
+        hostname: 'thenativeweb.io',
+        protocol: 'https',
+        type: 'permanent'
+      })).is.null();
+      done();
+    });
   });
 
   suite('returns a temporary redirect', function () {
@@ -101,6 +118,18 @@ suite('redirect', function () {
       })).is.equalTo({
         type: 'permanent',
         url: 'http://www.thenativeweb.io:4000/foo/bar'
+      });
+      done();
+    });
+
+    test('when non-www is preferred', function (done) {
+      assert.that(redirect('https', 'www.thenativeweb.io', '/foo/bar', {
+        hostname: 'thenativeweb.io',
+        protocol: 'https',
+        type: 'permanent'
+      })).is.equalTo({
+        type: 'permanent',
+        url: 'https://thenativeweb.io/foo/bar'
       });
       done();
     });

--- a/test/redirectTests.js
+++ b/test/redirectTests.js
@@ -5,13 +5,13 @@ var assert = require('assertthat');
 var redirect = require('../lib/redirect');
 
 suite('redirect', function () {
-  suite('returns undefined', function () {
+  suite('returns null', function () {
     test('for localhost.', function (done) {
       assert.that(redirect('http', 'localhost', '/foo/bar', {
         protocol: 'https',
         hostname: 'www.thenativeweb.io',
         port: 4000
-      })).is.undefined();
+      })).is.null();
       done();
     });
 
@@ -20,7 +20,7 @@ suite('redirect', function () {
         protocol: 'https',
         hostname: 'www.thenativeweb.io',
         port: 4000
-      })).is.undefined();
+      })).is.null();
       done();
     });
 
@@ -28,7 +28,7 @@ suite('redirect', function () {
       assert.that(redirect('http', 'www.thenativeweb.io:4000', '/foo/bar', {
         hostname: 'www.thenativeweb.io',
         port: 4000
-      })).is.undefined();
+      })).is.null();
       done();
     });
   });


### PR DESCRIPTION
For Googlebot / Bingbot it's commonly thought that there should be single, permanent copy of each document. 

I've also fixed some typos, added some tests and make some small tweaks.